### PR TITLE
Fix 1.6 tests with frames for Chrome 78

### DIFF
--- a/test/itg/1.6/globals.webdriverio.js
+++ b/test/itg/1.6/globals.webdriverio.js
@@ -35,8 +35,8 @@ module.exports = {
                 close_green_validation_button: '.alert.alert-success > .close',
                 proceed_installation_anyway_button: '//div[@id="moduleNotTrusted"]//a[@id="proceed-install-anyway"]',
                 menu: '#nav-sidebar',
-                summary_textarea: 'description_short_1_ifr', //not declare like an id because using into function "frame" that not need this information;
-                description_textarea: 'description_1_ifr',//not declare like an id because using into function "frame" that not need this information;
+                summary_textarea: '#description_short_1_ifr',
+                description_textarea: '#description_1_ifr',
                 product_price_tab: '#link-Prices',
                 wholesale_price_input: '#wholesale_price',
                 priceTE_input: '#priceTE',

--- a/test/itg/1.6/scenario/BO/create_product.webdriverio.js
+++ b/test/itg/1.6/scenario/BO/create_product.webdriverio.js
@@ -54,15 +54,18 @@ describe('The Product Creation', function () {
             global.fctname = this.test.title;
             this.client
                 .setValue(this.selector.BO.AddProductPage.product_name_input, 'test_nodejs_' + product_id)
-                .pause(60000)
+                .pause(5000)
                 .call(done);
         });
 
         it('should enter the product summary', function (done) {
             global.fctname = this.test.title;
+            const cl = this.client;
             this.client
-                .frame(this.selector.BO.AddProductPage.summary_textarea, function (err, result) {
-                    if (err) console.log(err);
+                .element(this.selector.BO.AddProductPage.summary_textarea).then(function(res) {
+                    return cl.frame(res.value, function (err, result) {
+                        if (err) console.log(err);
+                    });
                 })
                 .setValue("#tinymce", "this is the summary")
                 .frameParent()
@@ -72,9 +75,12 @@ describe('The Product Creation', function () {
 
         it('should enter the product description', function (done) {
             global.fctname = this.test.title;
+            const cl = this.client;
             this.client
-                .frame(this.selector.BO.AddProductPage.description_textarea, function (err, result) {
-                    if (err) console.log(err);
+                .element(this.selector.BO.AddProductPage.description_textarea).then(function(res) {
+                    return cl.frame(res.value, function (err, result) {
+                        if (err) console.log(err);
+                    });
                 })
                 .setValue("#tinymce", "this is the description")
                 .frameParent()
@@ -201,15 +207,18 @@ describe('The Product Creation', function () {
                 var my_name = text;
                 should(my_name).be.equal('test_nodejs_' + product_id);
             })
-                .pause(60000)
+                .pause(5000)
                 .call(done);
         });
 
         it('should check the product summary', function (done) {
             global.fctname = this.test.title;
+            const cl = this.client;
             this.client
-                .frame(this.selector.BO.AddProductPage.summary_textarea, function (err, result) {
-                    if (err) console.log(err);
+                .element(this.selector.BO.AddProductPage.summary_textarea).then(function(res) {
+                    return cl.frame(res.value, function (err, result) {
+                        if (err) console.log(err);
+                    });
                 })
                 .getText("#tinymce").then(function (text) {
                 var my_summary = text;
@@ -221,9 +230,12 @@ describe('The Product Creation', function () {
 
         it('should check the product description', function (done) {
             global.fctname = this.test.title;
+            const cl = this.client;
             this.client
-                .frame(this.selector.BO.AddProductPage.description_textarea, function (err, result) {
-                    if (err) console.log(err);
+                .element(this.selector.BO.AddProductPage.description_textarea).then(function(res) {
+                    return cl.frame(res.value, function (err, result) {
+                        if (err) console.log(err);
+                    });
                 })
                 .getText("#tinymce").then(function (text) {
                 var my_description = text;


### PR DESCRIPTION
Fix 1.6 tests for newer Chrome drivers which no longer accepts string selectors for `frame` method.